### PR TITLE
fix: correct spelling mistakes

### DIFF
--- a/cmake/CPM.cmake
+++ b/cmake/CPM.cmake
@@ -340,7 +340,7 @@ function(cpm_parse_add_package_single_arg arg outArgs)
     endif()
   endif()
 
-  # For all packages we interpret @... as version. Only replace the last occurence. Thus URIs
+  # For all packages we interpret @... as version. Only replace the last occurrence. Thus URIs
   # containing '@' can be used
   string(REGEX REPLACE "@([^@]+)$" ";VERSION;\\1" out "${out}")
 
@@ -379,7 +379,7 @@ function(cpm_check_git_working_dir_is_clean repoPath gitTag isClean)
     return()
   endif()
 
-  # check for uncommited changes
+  # check for uncommitted changes
   execute_process(
     COMMAND ${GIT_EXECUTABLE} status --porcelain
     RESULT_VARIABLE resultGitStatus
@@ -405,7 +405,7 @@ function(cpm_check_git_working_dir_is_clean repoPath gitTag isClean)
     return()
   endif()
 
-  # check for commited changes
+  # check for committed changes
   execute_process(
     COMMAND ${GIT_EXECUTABLE} diff -s --exit-code ${gitTag}
     RESULT_VARIABLE resultGitDiff
@@ -717,7 +717,7 @@ macro(cpm_export_variables name)
 endmacro()
 
 # declares a package, so that any call to CPMAddPackage for the package name will use these
-# arguments instead. Previous declarations will not be overriden.
+# arguments instead. Previous declarations will not be overridden.
 macro(CPMDeclarePackage Name)
   if(NOT DEFINED "CPM_DECLARATION_${Name}")
     set("CPM_DECLARATION_${Name}" "${ARGN}")
@@ -937,7 +937,7 @@ function(cpm_get_version_from_git_tag GIT_TAG RESULT)
   endif()
 endfunction()
 
-# guesses if the git tag is a commit hash or an actual tag or a branch nane.
+# guesses if the git tag is a commit hash or an actual tag or a branch name.
 function(cpm_is_git_tag_commit_hash GIT_TAG RESULT)
   string(LENGTH "${GIT_TAG}" length)
   # full hash has 40 characters, and short hash has at least 7 characters.

--- a/scx-rustlib/src/lib.rs
+++ b/scx-rustlib/src/lib.rs
@@ -193,7 +193,7 @@ impl Config {
         config_path: &str,
     ) -> Result<()> {
         // stop/disable 'scx.service' if its running/enabled on the system,
-        // overwise it will conflict
+        // otherwise it will conflict
         disable_scx_service();
 
         let default_args = self.get_scx_flags_for_mode(&scx_name, scx_mode)?;
@@ -294,7 +294,7 @@ pub fn get_supported_scheds() -> Result<Vec<String>> {
     });
 }
 
-/// Initialize config from first found config path, overwise fallback to default config
+/// Initialize config from first found config path, otherwise fallback to default config
 pub fn init_config(config_path: &str) -> Result<scx_loader::config::Config> {
     if Path::new(config_path).exists() {
         scx_loader::config::parse_config_file(config_path)
@@ -345,6 +345,6 @@ fn disable_scx_service() {
         println!("Disabling scx service");
     } else if is_scx_service_active() {
         spawn_child_process("/usr/bin/systemctl", &["stop", "-f", "scx"]);
-        println!("Stoping scx service");
+        println!("Stopping scx service");
     }
 }

--- a/src/schedext-window-internal.cpp
+++ b/src/schedext-window-internal.cpp
@@ -168,7 +168,7 @@ SchedExtWindow::SchedExtWindow(QWidget* parent)
         this,
         &SchedExtWindow::on_sched_profile_changed);
 
-    // Set currently runing scheduler mode
+    // Set currently running scheduler mode
     auto current_mode = m_scx_config->get_current_mode();
     if (current_mode.has_value()) {
         // NOTE: the index of profiles and scxmode values MUST match


### PR DESCRIPTION
- fix misspellings in cmake/CPM.cmake comments (occurrence, uncommitted, overridden, name)
- correct “running” comment in schedext-window-internal.cpp
- clean up wording and logs in scx-rustlib/src/lib.rs (otherwise, stopping)

Author: rezky_nightky <with.rezky@gmail.com>
Timestamp: 2025-11-30T15:15:23Z
Repository: scx-manager
Branch: master
Signing: GPG (989AF9F0)
Performance: 3 files, +9/-9 lines