### PR TITLE
scx-manager: add scx_cake

### DIFF
--- a/src/schedext-window-internal.cpp
+++ b/src/schedext-window-internal.cpp
@@ -234,7 +234,7 @@ void SchedExtWindow::on_sched_changed() noexcept {
     // NOTE: only some support different preset profiles at
     // the moment.
     using namespace std::string_view_literals;
-    constexpr std::array supported_scheds{"scx_bpfland"sv, "scx_lavd"sv, "scx_flash"sv, "scx_p2dq"sv, "scx_tickless"sv, "scx_cosmos"sv};
+    constexpr std::array supported_scheds{"scx_bpfland"sv, "scx_lavd"sv, "scx_flash"sv, "scx_p2dq"sv, "scx_tickless"sv, "scx_cosmos"sv, "scx_cake"sv}};
     if (std::ranges::any_of(supported_scheds, [&](auto&& supported_sched) { return supported_sched == scheduler; })) {
         m_ui->scheduler_profile_select_label->setVisible(true);
         m_ui->schedext_profile_combo_box->setVisible(true);

--- a/src/schedext-window-internal.cpp
+++ b/src/schedext-window-internal.cpp
@@ -234,7 +234,7 @@ void SchedExtWindow::on_sched_changed() noexcept {
     // NOTE: only some support different preset profiles at
     // the moment.
     using namespace std::string_view_literals;
-    constexpr std::array supported_scheds{"scx_bpfland"sv, "scx_lavd"sv, "scx_flash"sv, "scx_p2dq"sv, "scx_tickless"sv, "scx_cosmos"sv, "scx_cake"sv}};
+    constexpr std::array supported_scheds{"scx_bpfland"sv, "scx_lavd"sv, "scx_flash"sv, "scx_p2dq"sv, "scx_tickless"sv, "scx_cosmos"sv, "scx_cake"sv};
     if (std::ranges::any_of(supported_scheds, [&](auto&& supported_sched) { return supported_sched == scheduler; })) {
         m_ui->scheduler_profile_select_label->setVisible(true);
         m_ui->schedext_profile_combo_box->setVisible(true);


### PR DESCRIPTION
https://github.com/sched-ext/scx/pull/3202 Added scx_cake to sched-ext/scx, which is likely to appear in v1.0.21 of scx.

This prepares scx-manager for when scx_cake becomes available