### PR TITLE
UI: add Cancel button to sched-ext config window

### DIFF
--- a/lang/scx-manager_ca.ts
+++ b/lang/scx-manager_ca.ts
@@ -40,6 +40,11 @@
     </message>
     <message>
         <location filename="../src/schedext-window.ui" line="176"/>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/schedext-window.ui" line="176"/>
         <source>Disable</source>
         <translation>Inhabilita</translation>
     </message>

--- a/lang/scx-manager_cs.ts
+++ b/lang/scx-manager_cs.ts
@@ -40,6 +40,11 @@
     </message>
     <message>
         <location filename="../src/schedext-window.ui" line="176"/>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/schedext-window.ui" line="176"/>
         <source>Disable</source>
         <translation type="unfinished"></translation>
     </message>

--- a/lang/scx-manager_de.ts
+++ b/lang/scx-manager_de.ts
@@ -40,6 +40,11 @@
     </message>
     <message>
         <location filename="../src/schedext-window.ui" line="176"/>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/schedext-window.ui" line="176"/>
         <source>Disable</source>
         <translation type="unfinished"></translation>
     </message>

--- a/lang/scx-manager_pl.ts
+++ b/lang/scx-manager_pl.ts
@@ -40,6 +40,11 @@
     </message>
     <message>
         <location filename="../src/schedext-window.ui" line="176"/>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/schedext-window.ui" line="176"/>
         <source>Disable</source>
         <translation>Wyłącz</translation>
     </message>

--- a/lang/scx-manager_ru.ts
+++ b/lang/scx-manager_ru.ts
@@ -40,6 +40,11 @@
     </message>
     <message>
         <location filename="../src/schedext-window.ui" line="176"/>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/schedext-window.ui" line="176"/>
         <source>Disable</source>
         <translation>Отключить</translation>
     </message>

--- a/lang/scx-manager_sk.ts
+++ b/lang/scx-manager_sk.ts
@@ -40,6 +40,11 @@
     </message>
     <message>
         <location filename="../src/schedext-window.ui" line="176"/>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/schedext-window.ui" line="176"/>
         <source>Disable</source>
         <translation type="unfinished"></translation>
     </message>

--- a/lang/scx-manager_tr.ts
+++ b/lang/scx-manager_tr.ts
@@ -40,6 +40,11 @@
     </message>
     <message>
         <location filename="../src/schedext-window.ui" line="176"/>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/schedext-window.ui" line="176"/>
         <source>Disable</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/schedext-window-internal.cpp
+++ b/src/schedext-window-internal.cpp
@@ -187,6 +187,7 @@ SchedExtWindow::SchedExtWindow(QWidget* parent)
     // Connect buttons signal
     connect(m_ui->apply_button, &QPushButton::clicked, this, &SchedExtWindow::on_apply);
     connect(m_ui->disable_button, &QPushButton::clicked, this, &SchedExtWindow::on_disable);
+    connect(m_ui->cancel_button, &QPushButton::clicked, this, &SchedExtWindow::close);
 }
 
 void SchedExtWindow::closeEvent(QCloseEvent* event) {

--- a/src/schedext-window.ui
+++ b/src/schedext-window.ui
@@ -171,6 +171,13 @@
         </spacer>
        </item>
        <item>
+        <widget class="QPushButton" name="cancel_button">
+         <property name="text">
+          <string>Cancel</string>
+         </property>
+        </widget>
+       </item>
+       <item>
         <widget class="QPushButton" name="disable_button">
          <property name="text">
           <string>Disable</string>


### PR DESCRIPTION
This PR adds a Cancel button to the sched-ext configuration window, addressing the request in CachyOS/kernel-manager#39 for consistency with other windows in the application.