### PR TITLE
i18n: add Chinese (Simplified and Traditional) translations

### DIFF
--- a/lang/scx-manager_zh_CN.ts
+++ b/lang/scx-manager_zh_CN.ts
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="zh_CN">
+<context>
+    <name>SchedExtWindow</name>
+    <message>
+        <location filename="../src/schedext-window.ui" line="17"/>
+        <source>CachyOS Configure sched-ext</source>
+        <translation>CachyOS sched-ext 配置</translation>
+    </message>
+    <message>
+        <location filename="../src/schedext-window.ui" line="40"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p align=&quot;center&quot;&gt;Configure sched-ext scheduler:&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p align=&quot;center&quot;&gt;配置 sched-ext 调度器:&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/schedext-window.ui" line="75"/>
+        <source>Running sched-ext scheduler:</source>
+        <translation>正在运行的 sched-ext 调度器:</translation>
+    </message>
+    <message>
+        <location filename="../src/schedext-window.ui" line="82"/>
+        <source>Select sched-ext scheduler:</source>
+        <translation>选择 sched-ext 调度器:</translation>
+    </message>
+    <message>
+        <location filename="../src/schedext-window.ui" line="92"/>
+        <source>Select scheduler profile:</source>
+        <translation>选择调度器配置文件:</translation>
+    </message>
+    <message>
+        <location filename="../src/schedext-window.ui" line="115"/>
+        <source>unknown</source>
+        <translation>未知</translation>
+    </message>
+    <message>
+        <location filename="../src/schedext-window.ui" line="122"/>
+        <source>Set sched-ext extra scheduler flags:</source>
+        <translation>设置 sched-ext 额外调度器标志:</translation>
+    </message>
+    <message>
+        <location filename="../src/schedext-window.ui" line="176"/>
+        <source>Cancel</source>
+        <translation>取消</translation>
+    </message>
+    <message>
+        <location filename="../src/schedext-window.ui" line="183"/>
+        <source>Disable</source>
+        <translation>禁用</translation>
+    </message>
+    <message>
+        <location filename="../src/schedext-window.ui" line="190"/>
+        <source>Apply</source>
+        <translation>应用</translation>
+    </message>
+</context>
+<context>
+    <name>scxctl::impl::SchedExtWindow</name>
+    <message>
+        <location filename="../src/schedext-window-internal.cpp" line="122"/>
+        <source>Cannot initialize scx_loader configuration</source>
+        <translation>无法初始化 scx_loader 配置</translation>
+    </message>
+    <message>
+        <location filename="../src/schedext-window-internal.cpp" line="138"/>
+        <source>Cannot get information from scx_loader!
+Is it working?
+This is needed for the app to work properly</source>
+        <translation>无法从 scx_loader 获取信息！
+它是否在运行？
+这是应用程序正常运行所必需的</translation>
+    </message>
+    <message>
+        <location filename="../src/schedext-window-internal.cpp" line="206"/>
+        <source>Cannot disable scx_loader</source>
+        <translation>无法禁用 scx_loader</translation>
+    </message>
+    <message>
+        <location filename="../src/schedext-window-internal.cpp" line="224"/>
+        <source>Cannot get scx flags from scx_loader configuration!</source>
+        <translation>无法从 scx_loader 配置中获取 scx 标志！</translation>
+    </message>
+    <message>
+        <location filename="../src/schedext-window-internal.cpp" line="260"/>
+        <source>Cannot set default scx scheduler with mode! Scheduler %1 with mode %2</source>
+        <translation>无法设置默认 scx 调度器及其模式！调度器 %1，模式 %2</translation>
+    </message>
+</context>
+</TS>

--- a/lang/scx-manager_zh_TW.ts
+++ b/lang/scx-manager_zh_TW.ts
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="zh_TW">
+<context>
+    <name>SchedExtWindow</name>
+    <message>
+        <location filename="../src/schedext-window.ui" line="17"/>
+        <source>CachyOS Configure sched-ext</source>
+        <translation>CachyOS sched-ext 設定</translation>
+    </message>
+    <message>
+        <location filename="../src/schedext-window.ui" line="40"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p align=&quot;center&quot;&gt;Configure sched-ext scheduler:&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p align=&quot;center&quot;&gt;設定 sched-ext 排程器:&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/schedext-window.ui" line="75"/>
+        <source>Running sched-ext scheduler:</source>
+        <translation>正在執行的 sched-ext 排程器:</translation>
+    </message>
+    <message>
+        <location filename="../src/schedext-window.ui" line="82"/>
+        <source>Select sched-ext scheduler:</source>
+        <translation>選擇 sched-ext 排程器:</translation>
+    </message>
+    <message>
+        <location filename="../src/schedext-window.ui" line="92"/>
+        <source>Select scheduler profile:</source>
+        <translation>選擇排程器設定檔:</translation>
+    </message>
+    <message>
+        <location filename="../src/schedext-window.ui" line="115"/>
+        <source>unknown</source>
+        <translation>未知</translation>
+    </message>
+    <message>
+        <location filename="../src/schedext-window.ui" line="122"/>
+        <source>Set sched-ext extra scheduler flags:</source>
+        <translation>設定 sched-ext 額外排程器旗標:</translation>
+    </message>
+    <message>
+        <location filename="../src/schedext-window.ui" line="176"/>
+        <source>Cancel</source>
+        <translation>取消</translation>
+    </message>
+    <message>
+        <location filename="../src/schedext-window.ui" line="183"/>
+        <source>Disable</source>
+        <translation>停用</translation>
+    </message>
+    <message>
+        <location filename="../src/schedext-window.ui" line="190"/>
+        <source>Apply</source>
+        <translation>套用</translation>
+    </message>
+</context>
+<context>
+    <name>scxctl::impl::SchedExtWindow</name>
+    <message>
+        <location filename="../src/schedext-window-internal.cpp" line="122"/>
+        <source>Cannot initialize scx_loader configuration</source>
+        <translation>無法初始化 scx_loader 設定</translation>
+    </message>
+    <message>
+        <location filename="../src/schedext-window-internal.cpp" line="138"/>
+        <source>Cannot get information from scx_loader!
+Is it working?
+This is needed for the app to work properly</source>
+        <translation>無法從 scx_loader 取得資訊！
+它是否在執行？
+這是應用程式正常運作所必需的</translation>
+    </message>
+    <message>
+        <location filename="../src/schedext-window-internal.cpp" line="206"/>
+        <source>Cannot disable scx_loader</source>
+        <translation>無法停用 scx_loader</translation>
+    </message>
+    <message>
+        <location filename="../src/schedext-window-internal.cpp" line="224"/>
+        <source>Cannot get scx flags from scx_loader configuration!</source>
+        <translation>無法從 scx_loader 設定中取得 scx 旗標！</translation>
+    </message>
+    <message>
+        <location filename="../src/schedext-window-internal.cpp" line="260"/>
+        <source>Cannot set default scx scheduler with mode! Scheduler %1 with mode %2</source>
+        <translation>無法設定預設 scx 排程器及其模式！排程器 %1，模式 %2</translation>
+    </message>
+</context>
+</TS>

--- a/scx_manager_locale.qrc
+++ b/scx_manager_locale.qrc
@@ -12,5 +12,7 @@
         <file alias="ru">lang/scx-manager_ru.qm</file>
         <file alias="sk">lang/scx-manager_sk.qm</file>
         <file alias="tr">lang/scx-manager_tr.qm</file>
+        <file alias="zh_CN">lang/scx-manager_zh_CN.qm</file>
+        <file alias="zh_TW">lang/scx-manager_zh_TW.qm</file>
     </qresource>
 </RCC>


### PR DESCRIPTION
  ## Summary

  Add Chinese Simplified (zh_CN) and Chinese Traditional (zh_TW) language
  support to scx-manager. This adds two Qt translation files covering all
  15 translatable strings extracted from the UI form and C++ source, and
  registers both locale aliases in `scx_manager_locale.qrc` so that the
  `.qm` files are embedded and loaded for `zh_CN` and `zh_TW` system locales.
  ## Translation Notes
  
  **Simplified Chinese (zh_CN) — mainland China terminology:**
  - **"scheduler" → "调度器":** The standard term in mainland Chinese computing
    literature, widely used in Linux kernel and OS textbooks. 
  - **"flags" → "标志":** Standard translation for bit flags / option flags in
    software configuration contexts.
  - **"profile" → "配置文件":** Literally "configuration file", the idiomatic
    term in Simplified Chinese software UIs for a named settings preset.
  - **"Disable" → "禁用":** The standard verb for disabling/deactivating a
    feature. "禁" (prohibit/forbid) + "用" (use). 
  - **"Apply" → "应用":** The standard verb for committing a configuration
    change, same characters are used for "application" but in verb form it
    means "to apply".
    
  **Traditional Chinese (zh_TW) — Taiwan/Hong Kong terminology:**
  - **"scheduler" → "排程器":** The established term in Taiwan computing,
    notably different from the mainland term "调度器". "排程" (scheduling)
    + "器" (device/tool).
  - **"flags" → "旗標":** Taiwan standard translation for software flags,
    distinct from the mainland "标志". Uses the metaphor of a signal flag.
  - **"profile" → "設定檔":** Taiwan idiom for a configuration file/preset.
    "設定" (settings) + "檔" (file), compared to mainland "配置文件".
  - **"Disable" → "停用":** Taiwan standard — "停" (stop) + "用" (use),
    while mainland uses "禁用".
  - **"Apply" → "套用":** Taiwan standard verb for applying settings; on the
    mainland "应用" is used instead.
  - **Placeholder preservation:** The `%1` and `%2` format placeholders in
    `"Cannot set default scx scheduler with mode! Scheduler %1 with mode %2"`
    are preserved at their correct positions in both Chinese strings.
    
  ## Files Changed
```
   lang/scx-manager_zh_CN.ts   | 89 +++++++++++++++++++++++++++++++++++++++++++++
   lang/scx-manager_zh_TW.ts   | 89 +++++++++++++++++++++++++++++++++++++++++++++
   scx_manager_locale.qrc      |  2 ++
   3 files changed, 180 insertions(+)
```